### PR TITLE
Support for `.pages` on Documents

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,9 @@ AllCops:
 RSpec/SpecFilePathFormat:
   CustomTransform:
     MuPDF: mupdf
+
+Naming/MethodParameterName:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mupdf (0.3.0)
+    mupdf (0.4.0)
       open3
       zeitwerk
 

--- a/README.md
+++ b/README.md
@@ -30,3 +30,17 @@ The `info` command displays information about the document such as the number of
 info = document.info
 info.pages # e.g. 2
 ```
+
+#### Pages
+
+The `pages` command finds sizing information about the pages within a document:
+
+```ruby
+pages = document.pages
+pages.count # e.g. 2
+page = pages[0]
+page.pagenum # 1
+box = page.media_box # page.crop_box / page.bleed_box / page.trim_box / page.art_box
+box.width # 612
+box.height # 792
+```

--- a/lib/mupdf/box.rb
+++ b/lib/mupdf/box.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module MuPDF
+  # A bounding box for a PDF (e.g. media / crop / bleed / trim).
+  class Box
+    REGEX = /l="(?<l>\d+)" b="(?<b>\d+)" r="(?<r>\d+)" t="(?<t>\d+)"/
+
+    # @!attribute l
+    #   @return [String] The left coordinate.
+    attr_reader :l
+
+    # @!attribute b
+    #   @return [String] The bottom coordinate.
+    attr_reader :b
+
+    # @!attribute r
+    #   @return [String] The right coordinate.
+    attr_reader :r
+
+    # @!attribute t
+    #   @return [String] The top coordinate.
+    attr_reader :t
+
+    # @!attribute kind
+    #   @return [Symbol] The kind of box.
+    attr_reader :kind
+
+    # @param text [String]
+    # @param kind [Symbol]
+    #
+    # @return [MuPDF::Box]
+    def self.parse(text, kind:)
+      match = text.match(REGEX)
+
+      new(
+        l: Integer(match[:l]),
+        b: Integer(match[:b]),
+        r: Integer(match[:r]),
+        t: Integer(match[:t]),
+        kind:
+      )
+    end
+
+    # @param l [Integer]
+    # @param b [Integer]
+    # @param r [Integer]
+    # @param t [Integer]
+    # @param kind [Symbol] optional
+    def initialize(l:, b:, r:, t:, kind: nil)
+      @l = l
+      @b = b
+      @r = r
+      @t = t
+      @kind = kind
+    end
+
+    # @return [String]
+    def inspect
+      "#<#{self.class.name} l=#{l} b=#{b} r=#{r} t=#{t} kind=#{kind}>"
+    end
+
+    # @return [Integer]
+    def width
+      @r - @l
+    end
+
+    # @return [Integer]
+    def height
+      @t - @b
+    end
+  end
+end

--- a/lib/mupdf/document.rb
+++ b/lib/mupdf/document.rb
@@ -8,6 +8,11 @@ module MuPDF
       @pathname = pathname
     end
 
+    # @return [String]
+    def inspect
+      "#<#{self.class.name} pathname=#{@pathname}>"
+    end
+
     # @raise [MuPDF::CommandError]
     #
     # @return [MuPDF::Info]
@@ -15,6 +20,16 @@ module MuPDF
       @info ||= begin
         result = MuPDF.mutool('info', String(@pathname))
         MuPDF::Info.parse(result)
+      end
+    end
+
+    # @raise [MuPDF::CommandError]
+    #
+    # @return [Array<MuPDF::Page>]
+    def pages
+      @pages ||= begin
+        result = MuPDF.mutool('pages', String(@pathname))
+        MuPDF::Page.parse(result)
       end
     end
   end

--- a/lib/mupdf/page.rb
+++ b/lib/mupdf/page.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+module MuPDF
+  # A wrapper for a PDF page within a PDF document.
+  class Page
+    REGEX = %r{<page pagenum="(?<pagenum>\d+)">(?<content>.*?)</page>}m
+    MEDIA_BOX_REGEX = %r{<MediaBox (?<content>.*?) />}
+    CROP_BOX_REGEX = %r{<CropBox (?<content>.*?) />}
+    ART_BOX_REGEX = %r{<ArtBox (?<content>.*?) />}
+    BLEED_BOX_REGEX = %r{<BleedBox (?<content>.*?) />}
+    TRIM_BOX_REGEX = %r{<TrimBox (?<content>.*?) />}
+
+    # @param text [String]
+    #
+    # @return [Array<MuPDF::Page>]
+    def self.parse(text)
+      text.scan(REGEX).map do |pagenum, content|
+        new(
+          media_box: parse_media_box(content),
+          crop_box: parse_crop_box(content),
+          art_box: parse_art_box(content),
+          bleed_box: parse_bleed_box(content),
+          trim_box: parse_trim_box(content),
+          pagenum: Integer(pagenum)
+        )
+      end
+    end
+
+    # @param text [String]
+    #
+    # @return [MuPDF::Box]
+    def self.parse_media_box(text)
+      match = MEDIA_BOX_REGEX.match(text)
+      MuPDF::Box.parse(match[:content], kind: :media)
+    end
+
+    # @param text [String]
+    #
+    # @return [MuPDF::Box]
+    def self.parse_crop_box(text)
+      match = CROP_BOX_REGEX.match(text)
+      MuPDF::Box.parse(match[:content], kind: :crop)
+    end
+
+    # @param text [String]
+    #
+    # @return [MuPDF::Box]
+    def self.parse_art_box(text)
+      match = ART_BOX_REGEX.match(text)
+      MuPDF::Box.parse(match[:content], kind: :art)
+    end
+
+    # @param text [String]
+    #
+    # @return [MuPDF::Box]
+    def self.parse_bleed_box(text)
+      match = BLEED_BOX_REGEX.match(text)
+      MuPDF::Box.parse(match[:content], kind: :bleed)
+    end
+
+    # @param text [String]
+    #
+    # @return [MuPDF::Box]
+    def self.parse_trim_box(text)
+      match = TRIM_BOX_REGEX.match(text)
+      MuPDF::Box.parse(match[:content], kind: :trim)
+    end
+
+    # @!attribute media_box
+    #   @return [MuPDFBox]
+    attr_accessor :media_box
+
+    # @!attribute crop_box
+    #   @return [MuPDFBox]
+    attr_accessor :crop_box
+
+    # @!attribute art_box
+    #   @return [MuPDFBox]
+    attr_accessor :art_box
+
+    # @!attribute bleed_box
+    #   @return [MuPDFBox]
+    attr_accessor :bleed_box
+
+    # @!attribute trim_box
+    #   @return [MuPDFBox]
+    attr_accessor :trim_box
+
+    # @!attribute pagenum
+    #   @return [Integer]
+    attr_accessor :pagenum
+
+    # @param media_box [MuPDF::Box]
+    # @param crop_box [MuPDF::Box]
+    # @param art_box [MuPDF::Box]
+    # @param bleed_box [MuPDF::Box]
+    # @param trim_box [MuPDF::Box]
+    # @param pagenum [Integer]
+    def initialize(media_box:, crop_box:, art_box:, bleed_box:, trim_box:, pagenum:)
+      @media_box = media_box
+      @crop_box = crop_box
+      @art_box = art_box
+      @bleed_box = bleed_box
+      @trim_box = trim_box
+      @pagenum = pagenum
+    end
+
+    # @return [String]
+    def inspect
+      "#<#{self.class.name} pagenum=#{pagenum}>"
+    end
+  end
+end

--- a/lib/mupdf/version.rb
+++ b/lib/mupdf/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MuPDF
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end

--- a/spec/mupdf/box_spec.rb
+++ b/spec/mupdf/box_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe MuPDF::Box do
+  describe '.parse' do
+    subject(:parse) { described_class.parse(text, kind: :media) }
+
+    let(:text) { '<MediaBox l="0" b="0" r="612" t="792" />' }
+
+    it { is_expected.to be_a(described_class) }
+    it { expect(parse.l).to eq(0) }
+    it { expect(parse.b).to eq(0) }
+    it { expect(parse.r).to eq(612) }
+    it { expect(parse.t).to eq(792) }
+    it { expect(parse.width).to eq(612) }
+    it { expect(parse.height).to eq(792) }
+  end
+end

--- a/spec/mupdf/document_spec.rb
+++ b/spec/mupdf/document_spec.rb
@@ -6,7 +6,16 @@ RSpec.describe MuPDF::Document do
   let(:pathname) { 'spec/fixtures/file.pdf' }
 
   describe '#info' do
-    it { expect(document.info).to be_a(MuPDF::Info) }
-    it { expect(document.info.pages).to eq(2) }
+    subject(:info) { document.info }
+
+    it { expect(info).to be_a(MuPDF::Info) }
+    it { expect(info.pages).to eq(2) }
+  end
+
+  describe '#pages' do
+    subject(:pages) { document.pages }
+
+    it { expect(pages).to all(be_a(MuPDF::Page)) }
+    it { expect(pages.size).to eq(2) }
   end
 end

--- a/spec/mupdf/page_spec.rb
+++ b/spec/mupdf/page_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe MuPDF::Page do
+  describe '.parse' do
+    subject(:parse) { described_class.parse(text) }
+
+    let(:text) do
+      <<~TEXT
+        spec/fixtures/file.pdf:
+        <page pagenum="1">
+        <MediaBox l="0" b="0" r="612" t="792" />
+        <CropBox l="0" b="0" r="612" t="792" />
+        <ArtBox l="0" b="0" r="612" t="792" />
+        <BleedBox l="0" b="0" r="612" t="792" />
+        <TrimBox l="0" b="0" r="612" t="792" />
+        </page>
+        <page pagenum="2">
+        <MediaBox l="0" b="0" r="612" t="792" />
+        <CropBox l="0" b="0" r="612" t="792" />
+        <ArtBox l="0" b="0" r="612" t="792" />
+        <BleedBox l="0" b="0" r="612" t="792" />
+        <TrimBox l="0" b="0" r="612" t="792" />
+        </page>
+      TEXT
+    end
+
+    it { expect(parse).to all(be_a(described_class)) }
+    it { expect(parse.size).to eq(2) }
+  end
+end


### PR DESCRIPTION
The `pages` command finds sizing information about the pages within a document:

```ruby
pages = document.pages
pages.count # e.g. 2
page = pages[0]
page.pagenum # 1
box = page.media_box # page.crop_box / page.bleed_box / page.trim_box / page.art_box
box.width # 612
box.height # 792
```