### PR TITLE
Fix for Possibly Blank Boxes in `Page#parse`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mupdf (1.0.0)
+    mupdf (1.0.1)
       open3
       zeitwerk
 

--- a/lib/mupdf/box.rb
+++ b/lib/mupdf/box.rb
@@ -31,6 +31,7 @@ module MuPDF
     # @return [MuPDF::Box]
     def self.parse(text, kind:)
       match = text.match(REGEX)
+      return unless match
 
       new(
         l: Integer(match[:l]),

--- a/lib/mupdf/version.rb
+++ b/lib/mupdf/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MuPDF
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end


### PR DESCRIPTION
It appears that not every PDF page has a box containing it. This makes the parse logic for each page optional.