### PR TITLE
Switch from Integer to BigDecimal for Box

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: .
   specs:
-    mupdf (1.0.3)
+    mupdf (1.0.4)
+      bigdecimal
       open3
       zeitwerk
 
@@ -9,6 +10,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    bigdecimal (3.1.9)
     diff-lcs (1.5.1)
     docile (1.4.1)
     json (2.9.1)

--- a/lib/mupdf.rb
+++ b/lib/mupdf.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bigdecimal'
 require 'open3'
 require 'zeitwerk'
 

--- a/lib/mupdf/box.rb
+++ b/lib/mupdf/box.rb
@@ -3,26 +3,26 @@
 module MuPDF
   # A bounding box for a PDF (e.g. media / crop / bleed / trim).
   class Box
-    REGEX = /l="(?<l>\d+)" b="(?<b>\d+)" r="(?<r>\d+)" t="(?<t>\d+)"/
+    REGEX = /l="(?<l>\d+.?\d*)" b="(?<b>\d+.?\d*)" r="(?<r>\d+.?\d*)" t="(?<t>\d+.?\d*)"/
 
     # @!attribute l
-    #   @return [String] The left coordinate.
+    #   @return [BigDecimal] The left coordinate.
     attr_reader :l
 
     # @!attribute b
-    #   @return [String] The bottom coordinate.
+    #   @return [BigDecimal] The bottom coordinate.
     attr_reader :b
 
     # @!attribute r
-    #   @return [String] The right coordinate.
+    #   @return [BigDecimal] The right coordinate.
     attr_reader :r
 
     # @!attribute t
-    #   @return [String] The top coordinate.
+    #   @return [BigDecimal] The top coordinate.
     attr_reader :t
 
     # @!attribute kind
-    #   @return [Symbol] The kind of box.
+    #   @return [BigDecimal] The kind of box.
     attr_reader :kind
 
     # @param text [String]
@@ -34,18 +34,18 @@ module MuPDF
       return unless match
 
       new(
-        l: Integer(match[:l]),
-        b: Integer(match[:b]),
-        r: Integer(match[:r]),
-        t: Integer(match[:t]),
+        l: BigDecimal(match[:l]),
+        b: BigDecimal(match[:b]),
+        r: BigDecimal(match[:r]),
+        t: BigDecimal(match[:t]),
         kind:
       )
     end
 
-    # @param l [Integer]
-    # @param b [Integer]
-    # @param r [Integer]
-    # @param t [Integer]
+    # @param l [BigDecimal]
+    # @param b [BigDecimal]
+    # @param r [BigDecimal]
+    # @param t [BigDecimal]
     # @param kind [Symbol] optional
     def initialize(l:, b:, r:, t:, kind: nil)
       @l = l
@@ -60,12 +60,12 @@ module MuPDF
       "#<#{self.class.name} l=#{l} b=#{b} r=#{r} t=#{t} kind=#{kind}>"
     end
 
-    # @return [Integer]
+    # @return [BigDecimal]
     def width
       @r - @l
     end
 
-    # @return [Integer]
+    # @return [BigDecimal]
     def height
       @t - @b
     end

--- a/lib/mupdf/page.rb
+++ b/lib/mupdf/page.rb
@@ -120,12 +120,12 @@ module MuPDF
       "#<#{self.class.name} number=#{@number} width=#{width} height=#{height}>"
     end
 
-    # @return [Integer, nil]
+    # @return [BigDecimal, nil]
     def width
       @media_box&.width
     end
 
-    # @return [Integer, nil]
+    # @return [BigDecimal, nil]
     def height
       @media_box&.height
     end

--- a/lib/mupdf/version.rb
+++ b/lib/mupdf/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MuPDF
-  VERSION = '1.0.3'
+  VERSION = '1.0.4'
 end

--- a/mupdf.gemspec
+++ b/mupdf.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob('{bin,lib,exe}/**/*') + %w[README.md Gemfile]
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'bigdecimal'
   spec.add_dependency 'open3'
   spec.add_dependency 'zeitwerk'
 end


### PR DESCRIPTION
Some PDFs provide the width / height as a decimal. This fixes by always using a `BigDecimal`. Using a `BigDecimal` avoids any rounding issues.